### PR TITLE
Bug: Fix no change in answering buttons 

### DIFF
--- a/apps/Learning-Buddy/components/QuestionRadioGroup.jsx
+++ b/apps/Learning-Buddy/components/QuestionRadioGroup.jsx
@@ -29,7 +29,7 @@ export default function QuestionRadioGroup({ question, UpdateGivenAnswers, FindC
 
     // when user moves back to question preselected previous answer
     setCurrentRadio(FindCurrentChosenAnswer(question.prompt));
-  }, []);
+  }, [question]);
 
   // Combine two arrays into one to be rendered to frontend
   const  ShuffleOptions = (array1, array2) => {


### PR DESCRIPTION
forgot this change before merging branch to main just fixes a very small bug where the options for the questions on the answering page doesn't change. TY